### PR TITLE
It is better to use the repository field

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ description = "Music player library for esoteric audio formats (music from C64,A
 edition = "2021"
 build="build.rs"
 authors = [ "Jonas Minnberg <sasq64@gmail.com>" ]
-homepage = "https://github.com/sasq64/musicplayer"
+repository = "https://github.com/sasq64/musicplayer"
 exclude = ["/build", "/_skbuild", "/python", "/testmus", "/src/plugins/viceplugin",
     "/src/plugins/tfmxplugin", "/src/plugins/modplugin", "/src/plugins/mp3plugin", "/src/plugins/sexypsfplugin",
     "/external/lua", "/external/sol3", "/external/pybind11", "/music", "/src/catch.hpp"


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See also [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field).