### PR TITLE
It is better to use the repository field in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 build="build.rs"
 readme = "RUST.md"
 authors = [ "Jonas Minnberg <sasq64@gmail.com>" ]
-homepage = "https://github.com/sasq64/musicplayer"
+repository = "https://github.com/sasq64/musicplayer"
 exclude = ["/build", "/_skbuild", "/python", "/testmus", "/src/plugins/viceplugin",
     "/src/plugins/tfmxplugin", "/src/plugins/modplugin", "/src/plugins/mp3plugin", "/src/plugins/sexypsfplugin",
     "/external/lua", "/external/sol3", "/external/pybind11", "/music", "/src/catch.hpp"


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field) for the explanation.